### PR TITLE
Enabling multiple triggers for the same state if they have different conditional predicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+*.userprefs

--- a/LiquidState/Configuration/AwaitableStateConfigurationHelper.cs
+++ b/LiquidState/Configuration/AwaitableStateConfigurationHelper.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Threading.Tasks;
 using LiquidState.Common;
 using LiquidState.Representations;
@@ -84,7 +85,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitReentry(TTrigger trigger,
-            Func<Task> onEntryAsyncAction)
+                                                                                 Func<Task> onEntryAsyncAction)
         {
             Contract.Requires(trigger != null);
             Contract.Assume(currentStateRepresentation.State != null);
@@ -103,7 +104,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitReentryIf(Func<bool> predicate,
-            TTrigger trigger)
+                                                                                   TTrigger trigger)
         {
             Contract.Requires(trigger != null);
             Contract.Assume(currentStateRepresentation.State != null);
@@ -112,7 +113,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitReentryIf(Func<Task<bool>> predicate,
-            TTrigger trigger)
+                                                                                   TTrigger trigger)
         {
             Contract.Requires(trigger != null);
             Contract.Assume(currentStateRepresentation.State != null);
@@ -121,8 +122,8 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitReentryIf(Func<bool> predicate,
-            TTrigger trigger,
-            Action onEntryAction)
+                                                                                   TTrigger trigger,
+                                                                                   Action onEntryAction)
         {
             Contract.Requires(trigger != null);
             Contract.Assume(currentStateRepresentation.State != null);
@@ -131,8 +132,8 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitReentryIf<TArgument>(Func<bool> predicate,
-            ParameterizedTrigger<TTrigger, TArgument> trigger,
-            Action<TArgument> onEntryAction)
+                                                                                              ParameterizedTrigger<TTrigger, TArgument> trigger,
+                                                                                              Action<TArgument> onEntryAction)
         {
             Contract.Requires(trigger != null);
             Contract.Assume(currentStateRepresentation.State != null);
@@ -141,7 +142,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitReentryIf(Func<Task<bool>> predicate,
-            TTrigger trigger, Action onEntryAction)
+                                                                                   TTrigger trigger, Action onEntryAction)
         {
             Contract.Requires(trigger != null);
             Contract.Assume(currentStateRepresentation.State != null);
@@ -168,7 +169,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> Permit(TTrigger trigger, TState resultingState,
-            Action onEntryAction)
+                                                                          Action onEntryAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -187,7 +188,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> Permit(TTrigger trigger, TState resultingState,
-            Func<Task> onEntryAsyncAction)
+                                                                          Func<Task> onEntryAsyncAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -206,7 +207,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf(Func<bool> predicate, TTrigger trigger,
-            TState resultingState)
+                                                                            TState resultingState)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -215,7 +216,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf(Func<Task<bool>> predicate, TTrigger trigger,
-            TState resultingState)
+                                                                            TState resultingState)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -224,7 +225,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf(Func<bool> predicate, TTrigger trigger,
-            TState resultingState, Action onEntryAction)
+                                                                            TState resultingState, Action onEntryAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -233,8 +234,8 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf<TArgument>(Func<bool> predicate,
-            ParameterizedTrigger<TTrigger, TArgument> trigger,
-            TState resultingState, Action<TArgument> onEntryAction)
+                                                                                       ParameterizedTrigger<TTrigger, TArgument> trigger,
+                                                                                       TState resultingState, Action<TArgument> onEntryAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -243,7 +244,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf(Func<Task<bool>> predicate, TTrigger trigger,
-            TState resultingState, Action onEntryAction)
+                                                                            TState resultingState, Action onEntryAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -252,8 +253,8 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf<TArgument>(Func<Task<bool>> predicate,
-            ParameterizedTrigger<TTrigger, TArgument> trigger,
-            TState resultingState, Action<TArgument> onEntryAction)
+                                                                                       ParameterizedTrigger<TTrigger, TArgument> trigger,
+                                                                                       TState resultingState, Action<TArgument> onEntryAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -262,7 +263,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf(Func<bool> predicate, TTrigger trigger,
-            TState resultingState, Func<Task> onEntryAsyncAction)
+                                                                            TState resultingState, Func<Task> onEntryAsyncAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -271,8 +272,8 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf<TArgument>(Func<bool> predicate,
-            ParameterizedTrigger<TTrigger, TArgument> trigger,
-            TState resultingState, Func<TArgument, Task> onEntryAsyncAction)
+                                                                                       ParameterizedTrigger<TTrigger, TArgument> trigger,
+                                                                                       TState resultingState, Func<TArgument, Task> onEntryAsyncAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -281,7 +282,7 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf(Func<Task<bool>> predicate, TTrigger trigger,
-            TState resultingState, Func<Task> onEntryAsyncAction)
+                                                                            TState resultingState, Func<Task> onEntryAsyncAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -290,8 +291,8 @@ namespace LiquidState.Configuration
         }
 
         public AwaitableStateConfigurationHelper<TState, TTrigger> PermitIf<TArgument>(Func<Task<bool>> predicate,
-            ParameterizedTrigger<TTrigger, TArgument> trigger,
-            TState resultingState, Func<TArgument, Task> onEntryAsyncAction)
+                                                                                       ParameterizedTrigger<TTrigger, TArgument> trigger,
+                                                                                       TState resultingState, Func<TArgument, Task> onEntryAsyncAction)
         {
             Contract.Requires(trigger != null);
             Contract.Requires(resultingState != null);
@@ -321,7 +322,7 @@ namespace LiquidState.Configuration
         }
 
         internal static AwaitableStateRepresentation<TState, TTrigger> FindOrCreateStateRepresentation(TState state,
-            Dictionary<TState, AwaitableStateRepresentation<TState, TTrigger>> config)
+                                                                                                       Dictionary<TState, AwaitableStateRepresentation<TState, TTrigger>> config)
         {
             Contract.Requires(state != null);
             Contract.Requires(config != null);
@@ -331,7 +332,8 @@ namespace LiquidState.Configuration
             AwaitableStateRepresentation<TState, TTrigger> rep;
             if (config.TryGetValue(state, out rep))
             {
-                if (rep != null) return rep;
+                if (rep != null)
+                    return rep;
             }
             rep = new AwaitableStateRepresentation<TState, TTrigger>(state);
 
@@ -340,36 +342,58 @@ namespace LiquidState.Configuration
             return rep;
         }
 
-        internal static AwaitableTriggerRepresentation<TTrigger, TState> FindOrCreateTriggerConfig(TTrigger trigger,
-            AwaitableStateRepresentation<TState, TTrigger> stateRepresentation)
+        internal static AwaitableTriggerRepresentation<TTrigger, TState> FindOrCreateTriggerRepresentation(TTrigger trigger,
+                                                                                                           object predicate,
+                                                                                                           AwaitableStateRepresentation<TState, TTrigger> stateRepresentation)
         {
             Contract.Requires(stateRepresentation != null);
             Contract.Requires(trigger != null);
 
             Contract.Ensures(Contract.Result<AwaitableTriggerRepresentation<TTrigger, TState>>() != null);
 
-            var rep = FindTriggerRepresentation(trigger, stateRepresentation);
-            if (rep != null) return rep;
+            var repList = FindTriggerRepresentation(trigger, stateRepresentation);
+            if (repList != null && repList.Count == 1)
+            {
+                var rep = repList[0];
+                if (rep.ConditionalTriggerPredicate == predicate)
+                {
+                    Contract.Assume(rep.Trigger != null);
+                    return rep;
+                }
+            }
+                
+            foreach (var rep in repList)
+            {
+                if (rep.Trigger.Equals(trigger) &&
+                    rep.ConditionalTriggerPredicate == predicate)
+                {
+                    Contract.Assume(rep.Trigger != null);
+                    return rep;
+                }
+            }
 
-            rep = new AwaitableTriggerRepresentation<TTrigger, TState>(trigger);
-            stateRepresentation.Triggers.Add(rep);
-            return rep;
+            var newRep = new AwaitableTriggerRepresentation<TTrigger, TState>(trigger);
+            stateRepresentation.Triggers.Add(newRep, null);
+            return newRep;
         }
 
-        internal static AwaitableTriggerRepresentation<TTrigger, TState> FindTriggerRepresentation(TTrigger trigger,
-            AwaitableStateRepresentation<TState, TTrigger> stateRepresentation)
+        internal static List<AwaitableTriggerRepresentation<TTrigger, TState>> FindTriggerRepresentation(TTrigger trigger,
+                                                                                                         AwaitableStateRepresentation<TState, TTrigger> stateRepresentation)
         {
-            return stateRepresentation.Triggers.Find(x => x.Trigger.Equals(trigger));
+            var list = from state in stateRepresentation.Triggers
+                                where state.Key.Trigger.Equals(trigger)
+                                select state.Key;
+            return list.ToList();
         }
 
         private AwaitableStateConfigurationHelper<TState, TTrigger> PermitInternalSync(Func<bool> predicate,
-            TTrigger trigger,
-            TState resultingState, Action onEntryAction)
+                                                                                       TTrigger trigger,
+                                                                                       TState resultingState, Action onEntryAction)
         {
             Contract.Requires<ArgumentNullException>(trigger != null);
             Contract.Requires<ArgumentNullException>(resultingState != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = FindOrCreateStateRepresentation(resultingState, config);
             rep.OnTriggerAction = onEntryAction;
@@ -379,15 +403,15 @@ namespace LiquidState.Configuration
         }
 
         private AwaitableStateConfigurationHelper<TState, TTrigger> PermitInternalSync<TArgument>(Func<bool> predicate,
-            ParameterizedTrigger<TTrigger, TArgument> trigger,
-            TState resultingState, Action<TArgument> onEntryAction)
+                                                                                                  ParameterizedTrigger<TTrigger, TArgument> trigger,
+                                                                                                  TState resultingState, Action<TArgument> onEntryAction)
         {
             Contract.Requires<ArgumentNullException>(trigger != null);
             Contract.Requires<ArgumentNullException>(resultingState != null);
 
             Contract.Assume(trigger.Trigger != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger.Trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger.Trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = FindOrCreateStateRepresentation(resultingState, config);
             rep.OnTriggerAction = onEntryAction;
@@ -397,13 +421,13 @@ namespace LiquidState.Configuration
         }
 
         private AwaitableStateConfigurationHelper<TState, TTrigger> PermitInternalAsync(Func<Task<bool>> predicate,
-            TTrigger trigger,
-            TState resultingState, Func<Task> onEntryAsyncAction)
+                                                                                        TTrigger trigger,
+                                                                                        TState resultingState, Func<Task> onEntryAsyncAction)
         {
             Contract.Requires<ArgumentNullException>(trigger != null);
             Contract.Requires<ArgumentNullException>(resultingState != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = FindOrCreateStateRepresentation(resultingState, config);
             rep.OnTriggerAction = onEntryAsyncAction;
@@ -424,7 +448,7 @@ namespace LiquidState.Configuration
 
             Contract.Assume(trigger.Trigger != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger.Trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger.Trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = FindOrCreateStateRepresentation(resultingState, config);
             rep.OnTriggerAction = onEntryAsyncAction;
@@ -436,13 +460,13 @@ namespace LiquidState.Configuration
         }
 
         private AwaitableStateConfigurationHelper<TState, TTrigger> PermitInternalTriggerAsync(Func<bool> predicate,
-            TTrigger trigger,
-            TState resultingState, Func<Task> onEntryAsyncAction)
+                                                                                               TTrigger trigger,
+                                                                                               TState resultingState, Func<Task> onEntryAsyncAction)
         {
             Contract.Requires<ArgumentNullException>(trigger != null);
             Contract.Requires<ArgumentNullException>(resultingState != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = FindOrCreateStateRepresentation(resultingState, config);
             rep.OnTriggerAction = onEntryAsyncAction;
@@ -462,7 +486,7 @@ namespace LiquidState.Configuration
 
             Contract.Assume(trigger.Trigger != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger.Trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger.Trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = FindOrCreateStateRepresentation(resultingState, config);
             rep.OnTriggerAction = onEntryAsyncAction;
@@ -480,7 +504,7 @@ namespace LiquidState.Configuration
             Contract.Requires<ArgumentNullException>(trigger != null);
             Contract.Requires<ArgumentNullException>(resultingState != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = FindOrCreateStateRepresentation(resultingState, config);
             rep.OnTriggerAction = onEntryAsyncAction;
@@ -500,7 +524,7 @@ namespace LiquidState.Configuration
 
             Contract.Assume(trigger.Trigger != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger.Trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger.Trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = FindOrCreateStateRepresentation(resultingState, config);
             rep.OnTriggerAction = onEntryAsyncAction;
@@ -511,11 +535,11 @@ namespace LiquidState.Configuration
         }
 
         private AwaitableStateConfigurationHelper<TState, TTrigger> IgnoreInternal(Func<bool> predicate,
-            TTrigger trigger)
+                                                                                   TTrigger trigger)
         {
             Contract.Requires<ArgumentNullException>(trigger != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = null;
             rep.ConditionalTriggerPredicate = predicate;
@@ -529,7 +553,7 @@ namespace LiquidState.Configuration
         {
             Contract.Requires<ArgumentNullException>(trigger != null);
 
-            var rep = FindOrCreateTriggerConfig(trigger, currentStateRepresentation);
+            var rep = FindOrCreateTriggerRepresentation(trigger, predicate, currentStateRepresentation);
 
             rep.NextStateRepresentation = null;
             rep.ConditionalTriggerPredicate = predicate;

--- a/LiquidState/Machines/BlockingStateMachine.cs
+++ b/LiquidState/Machines/BlockingStateMachine.cs
@@ -41,7 +41,8 @@ namespace LiquidState.Machines
         {
             lock (syncRoot)
             {
-                if (!IsEnabled) return;
+                if (!IsEnabled)
+                    return;
                 StateRepresentation<TState, TTrigger> rep;
                 if (configDictionary.TryGetValue(state, out rep))
                 {
@@ -69,7 +70,8 @@ namespace LiquidState.Machines
         {
             foreach (var current in CurrentStateRepresentation.Triggers)
             {
-                if (current.Trigger.Equals(trigger)) return true;
+                if (current.Key.Trigger.Equals(trigger))
+                    return true;
             }
 
             return false;
@@ -79,7 +81,7 @@ namespace LiquidState.Machines
         {
             foreach (var current in CurrentStateRepresentation.Triggers)
             {
-                if (current.NextStateRepresentation.State.Equals(state))
+                if (current.Key.NextStateRepresentation.State.Equals(state))
                     return true;
             }
 
@@ -100,32 +102,51 @@ namespace LiquidState.Machines
         {
             lock (syncRoot)
             {
-                if (!IsEnabled) return;
+                if (!IsEnabled)
+                    return;
                 var trigger = parameterizedTrigger.Trigger;
                 var triggerRep = StateConfigurationHelper<TState, TTrigger>.FindTriggerRepresentation(trigger,
-                    CurrentStateRepresentation);
+                                     CurrentStateRepresentation);
 
-                if (triggerRep == null)
+                if (triggerRep == null || triggerRep.Count == 0)
                 {
                     HandleInvalidTrigger(trigger);
                     return;
                 }
 
                 var previousState = CurrentState;
+                TriggerRepresentation<TTrigger, TState> rep = null;
 
-                var predicate = triggerRep.ConditionalTriggerPredicate;
-                if (predicate != null)
+                foreach (var item in triggerRep)
                 {
-                    if (!predicate())
+                    var predicate = item.ConditionalTriggerPredicate;
+                    if (predicate == null)
                     {
-                        HandleInvalidTrigger(trigger);
-                        return;
+                        if (triggerRep.Count > 1)
+                        {
+                            throw new InvalidOperationException("Default triggers and conditional triggers cannot be used on the same resulting state");
+                        }
+
+                        rep = item;
                     }
+                    else
+                    {
+                        if (predicate() && rep == null)
+                        {
+                            rep = item;
+                        }
+                    }
+                }
+
+                if (rep == null)
+                {
+                    HandleInvalidTrigger(trigger);
+                    return;
                 }
 
                 // Handle ignored trigger
 
-                if (triggerRep.NextStateRepresentation == null)
+                if (rep.NextStateRepresentation == null)
                 {
                     return;
                 }
@@ -135,7 +156,7 @@ namespace LiquidState.Machines
                 Action<TArgument> triggerAction = null;
                 try
                 {
-                    triggerAction = (Action<TArgument>) triggerRep.OnTriggerAction;
+                    triggerAction = (Action<TArgument>)rep.OnTriggerAction;
                 }
                 catch (InvalidCastException)
                 {
@@ -149,10 +170,11 @@ namespace LiquidState.Machines
                 ExecuteAction(currentExit);
 
                 // Trigger entry
-                if (triggerAction != null) triggerAction.Invoke(argument);
+                if (triggerAction != null)
+                    triggerAction.Invoke(argument);
 
 
-                var nextStateRep = triggerRep.NextStateRepresentation;
+                var nextStateRep = rep.NextStateRepresentation;
 
                 // Next entry
                 var nextEntry = nextStateRep.OnEntryAction;
@@ -171,31 +193,50 @@ namespace LiquidState.Machines
         {
             lock (syncRoot)
             {
-                if (!IsEnabled) return;
+                if (!IsEnabled)
+                    return;
                 var triggerRep = StateConfigurationHelper<TState, TTrigger>.FindTriggerRepresentation(trigger,
-                    CurrentStateRepresentation);
+                                     CurrentStateRepresentation);
 
-                if (triggerRep == null)
+                if (triggerRep == null || triggerRep.Count == 0)
                 {
                     HandleInvalidTrigger(trigger);
                     return;
                 }
 
                 var previousState = CurrentState;
+                TriggerRepresentation<TTrigger, TState> rep = null;
 
-                var predicate = triggerRep.ConditionalTriggerPredicate;
-                if (predicate != null)
+                foreach (var item in triggerRep)
                 {
-                    if (!predicate())
+                    var predicate = item.ConditionalTriggerPredicate;
+                    if (predicate == null)
                     {
-                        HandleInvalidTrigger(trigger);
-                        return;
+                        if (triggerRep.Count > 1)
+                        {
+                            throw new InvalidOperationException("Defaul triggers and conditional triggers cannot be used on the same resulting state");
+                        }
+
+                        rep = item;
                     }
+                    else
+                    {
+                        if (predicate() && rep == null)
+                        {
+                            rep = item;
+                        }
+                    }
+                }
+
+                if (rep == null)
+                {
+                    HandleInvalidTrigger(trigger);
+                    return;
                 }
 
                 // Handle ignored trigger
 
-                if (triggerRep.NextStateRepresentation == null)
+                if (rep.NextStateRepresentation == null)
                 {
                     return;
                 }
@@ -205,7 +246,7 @@ namespace LiquidState.Machines
                 Action triggerAction = null;
                 try
                 {
-                    triggerAction = (Action) triggerRep.OnTriggerAction;
+                    triggerAction = (Action)rep.OnTriggerAction;
                 }
                 catch (InvalidCastException)
                 {
@@ -221,7 +262,7 @@ namespace LiquidState.Machines
                 // Trigger entry
                 ExecuteAction(triggerAction);
 
-                var nextStateRep = triggerRep.NextStateRepresentation;
+                var nextStateRep = rep.NextStateRepresentation;
 
                 // Next entry
                 var nextEntry = nextStateRep.OnEntryAction;
@@ -250,7 +291,7 @@ namespace LiquidState.Machines
         {
             get
             {
-                foreach (var triggerRepresentation in CurrentStateRepresentation.Triggers)
+                foreach (var triggerRepresentation in CurrentStateRepresentation.Triggers.Keys)
                 {
                     yield return triggerRepresentation.Trigger;
                 }
@@ -264,13 +305,15 @@ namespace LiquidState.Machines
 
         private void ExecuteAction(Action action)
         {
-            if (action != null) action.Invoke();
+            if (action != null)
+                action.Invoke();
         }
 
         private void HandleInvalidTrigger(TTrigger trigger)
         {
             var handler = UnhandledTriggerExecuted;
-            if (handler != null) handler.Invoke(trigger, CurrentStateRepresentation.State);
+            if (handler != null)
+                handler.Invoke(trigger, CurrentStateRepresentation.State);
         }
     }
 }

--- a/LiquidState/Representations/AwaitableStateRepresentation.cs
+++ b/LiquidState/Representations/AwaitableStateRepresentation.cs
@@ -12,7 +12,7 @@ namespace LiquidState.Representations
     internal class AwaitableStateRepresentation<TState, TTrigger>
     {
         public readonly TState State;
-        public readonly List<AwaitableTriggerRepresentation<TTrigger, TState>> Triggers;
+        public readonly Dictionary<AwaitableTriggerRepresentation<TTrigger, TState>, Func<bool>> Triggers;
         public object OnEntryAction;
         public object OnExitAction;
         public AwaitableStateTransitionFlag TransitionFlags;
@@ -26,7 +26,7 @@ namespace LiquidState.Representations
 
             State = state;
             // Allocate with capacity as 1 to avoid wastage of memory.
-            Triggers = new List<AwaitableTriggerRepresentation<TTrigger, TState>>(1);
+            Triggers = new Dictionary<AwaitableTriggerRepresentation<TTrigger, TState>, Func<bool>>(1);
         }
     }
 

--- a/LiquidState/Representations/Representation.cs
+++ b/LiquidState/Representations/Representation.cs
@@ -12,7 +12,7 @@ namespace LiquidState.Representations
     internal class StateRepresentation<TState, TTrigger>
     {
         public readonly TState State;
-        public readonly List<TriggerRepresentation<TTrigger, TState>> Triggers;
+        public readonly Dictionary<TriggerRepresentation<TTrigger, TState>, Func<bool>> Triggers;
         public Action OnEntryAction;
         public Action OnExitAction;
 
@@ -23,7 +23,7 @@ namespace LiquidState.Representations
 
             State = state;
             // Allocate with capacity as 1 to avoid wastage of memory.
-            Triggers = new List<TriggerRepresentation<TTrigger, TState>>(1);
+            Triggers = new Dictionary<TriggerRepresentation<TTrigger, TState>, Func<bool>>(1);
         }
     }
 


### PR DESCRIPTION
This changes follow these rules:

* Throws an InvalidOperationException with the message: "Default triggers and conditional triggers cannot be used on the same resulting state" if the state has triggers with and without a conditions at the same time
* Enters an invalid trigger state if all conditional predates return false

This makes possible to branch a state on multiple conditionals and switch among different final states. This also makes possible to create state machines that embeds some intelligence and also to use triggers as interface component actions with validation.