### PR TITLE
For dynamic states, pass trigger parameter to target state predicate.

### DIFF
--- a/LiquidState/Awaitable/Core/AwaitableDiagnosticsHelper.cs
+++ b/LiquidState/Awaitable/Core/AwaitableDiagnosticsHelper.cs
@@ -35,6 +35,22 @@ namespace LiquidState.Awaitable.Core
             return dynamicState.CanTransition ? new DynamicState<TState>?(dynamicState) : null;
         }
 
+        internal static async Task<DynamicState<TState>?> GetValidatedDynamicTransition<TState, TTrigger, TArgument>(
+            AwaitableTriggerRepresentation<TTrigger> triggerRep, TArgument argument)
+        {
+            DynamicState<TState> dynamicState;
+            if (AwaitableStateConfigurationHelper.CheckFlag(triggerRep.AwaitableTransitionFlags,
+                AwaitableTransitionFlag.DynamicStateReturnsTask)) {
+                dynamicState = await ((Func<TArgument, Task<DynamicState<TState>>>) triggerRep.NextStateRepresentationWrapper)(argument);
+            }
+            else
+            {
+                dynamicState = ((Func<TArgument, DynamicState<TState>>) triggerRep.NextStateRepresentationWrapper)(argument);
+            }
+
+            return dynamicState.CanTransition ? new DynamicState<TState>?(dynamicState) : null;
+        }
+
         internal static async Task<AwaitableTriggerRepresentation<TTrigger>>
             FindAndEvaluateTriggerRepresentationAsync
             <TState, TTrigger>(TTrigger trigger, RawAwaitableStateMachineBase<TState, TTrigger> machine,

--- a/LiquidState/Awaitable/Core/AwaitableExecutionHelper.cs
+++ b/LiquidState/Awaitable/Core/AwaitableExecutionHelper.cs
@@ -223,7 +223,7 @@ namespace LiquidState.Awaitable.Core
                 AwaitableTransitionFlag.DynamicState))
             {
                 var dynamicState =
-                    await AwaitableDiagnosticsHelper.GetValidatedDynamicTransition<TState, TTrigger>(triggerRep);
+                    await AwaitableDiagnosticsHelper.GetValidatedDynamicTransition<TState, TTrigger, TArgument>(triggerRep, argument);
                 if (dynamicState == null) return;
 
                 var state = dynamicState.Value.ResultingState;

--- a/LiquidState/Awaitable/Core/AwaitableStateConfiguration.cs
+++ b/LiquidState/Awaitable/Core/AwaitableStateConfiguration.cs
@@ -370,6 +370,41 @@ namespace LiquidState.Awaitable.Core
             Func<DynamicState<TState>> targetStateFunc,
             Action<Transition<TState, TTrigger>, TArgument> onTriggerAction)
         {
+            return PermitDynamic(trigger, a => targetStateFunc(), onTriggerAction);
+        }
+
+
+        public AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument>(
+            ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<Task<DynamicState<TState>>> targetStateFunc,
+            Action<Transition<TState, TTrigger>, TArgument> onTriggerAction)
+        {
+            return PermitDynamic(trigger, a => targetStateFunc(), onTriggerAction);
+        }
+
+
+        public AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument>(
+            ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<DynamicState<TState>> targetStateFunc,
+            Func<Transition<TState, TTrigger>, TArgument, Task> onTriggerAction)
+        {
+            return PermitDynamic(trigger, a => targetStateFunc(), onTriggerAction);
+        }
+
+
+        public AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument>(
+            ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<Task<DynamicState<TState>>> targetStateFunc,
+            Func<Transition<TState, TTrigger>, TArgument, Task> onTriggerAction)
+        {
+            return PermitDynamic(trigger, a => targetStateFunc(), onTriggerAction);
+        }
+
+        public AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument>(
+            ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<TArgument, DynamicState<TState>> targetStateFunc,
+            Action<Transition<TState, TTrigger>, TArgument> onTriggerAction)
+        {
             return Helper.PermitDynamic(this, trigger.Trigger, targetStateFunc,
                 onTriggerAction, AwaitableTransitionFlag.DynamicState);
         }
@@ -377,7 +412,7 @@ namespace LiquidState.Awaitable.Core
 
         public AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument>(
             ParameterizedTrigger<TTrigger, TArgument> trigger,
-            Func<Task<DynamicState<TState>>> targetStateFunc,
+            Func<TArgument, Task<DynamicState<TState>>> targetStateFunc,
             Action<Transition<TState, TTrigger>, TArgument> onTriggerAction)
         {
             return Helper.PermitDynamic(this, trigger.Trigger, targetStateFunc,
@@ -388,7 +423,7 @@ namespace LiquidState.Awaitable.Core
 
         public AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument>(
             ParameterizedTrigger<TTrigger, TArgument> trigger,
-            Func<DynamicState<TState>> targetStateFunc,
+            Func<TArgument, DynamicState<TState>> targetStateFunc,
             Func<Transition<TState, TTrigger>, TArgument, Task> onTriggerAction)
         {
             return Helper.PermitDynamic(this, trigger.Trigger, targetStateFunc,
@@ -400,7 +435,7 @@ namespace LiquidState.Awaitable.Core
 
         public AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument>(
             ParameterizedTrigger<TTrigger, TArgument> trigger,
-            Func<Task<DynamicState<TState>>> targetStateFunc,
+            Func<TArgument, Task<DynamicState<TState>>> targetStateFunc,
             Func<Transition<TState, TTrigger>, TArgument, Task> onTriggerAction)
         {
             return Helper.PermitDynamic(this, trigger.Trigger, targetStateFunc,

--- a/LiquidState/Extensions/AwaitableStateConfigurationExtensions.cs
+++ b/LiquidState/Extensions/AwaitableStateConfigurationExtensions.cs
@@ -321,6 +321,46 @@ namespace LiquidState
             return config.PermitDynamic(trigger, targetStateFunc, (t, a) => onTriggerAction(a));
         }
 
+        public static AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument, TState, TTrigger>(
+            this AwaitableStateConfiguration<TState, TTrigger> config, ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<TArgument, Task<DynamicState<TState>>> targetStateFunc,
+            Func<TArgument, Task> onTriggerAction)
+        {
+            Contract.NotNull(onTriggerAction != null, nameof(onTriggerAction));
+
+            return config.PermitDynamic(trigger, targetStateFunc, (t, a) => onTriggerAction(a));
+        }
+
+        public static AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument, TState, TTrigger>(
+            this AwaitableStateConfiguration<TState, TTrigger> config, ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<TArgument, DynamicState<TState>> targetStateFunc,
+            Action<TArgument> onTriggerAction)
+        {
+            Contract.NotNull(onTriggerAction != null, nameof(onTriggerAction));
+
+            return config.PermitDynamic(trigger, targetStateFunc, (t, a) => onTriggerAction(a));
+        }
+
+        public static AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument, TState, TTrigger>(
+            this AwaitableStateConfiguration<TState, TTrigger> config, ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<TArgument, Task<DynamicState<TState>>> targetStateFunc,
+            Action<TArgument> onTriggerAction)
+        {
+            Contract.NotNull(onTriggerAction != null, nameof(onTriggerAction));
+
+            return config.PermitDynamic(trigger, targetStateFunc, (t, a) => onTriggerAction(a));
+        }
+
+        public static AwaitableStateConfiguration<TState, TTrigger> PermitDynamic<TArgument, TState, TTrigger>(
+            this AwaitableStateConfiguration<TState, TTrigger> config, ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<TArgument, DynamicState<TState>> targetStateFunc,
+            Func<TArgument, Task> onTriggerAction)
+        {
+            Contract.NotNull(onTriggerAction != null, nameof(onTriggerAction));
+
+            return config.PermitDynamic(trigger, targetStateFunc, (t, a) => onTriggerAction(a));
+        }
+
         #endregion
     }
 }

--- a/LiquidState/Extensions/StateConfigurationExtensions.cs
+++ b/LiquidState/Extensions/StateConfigurationExtensions.cs
@@ -133,5 +133,17 @@ namespace LiquidState
             return config.PermitDynamic(trigger, targetStatePredicate,
                 (t, a) => onTriggerAction(a));
         }
+
+        public static StateConfiguration<TState, TTrigger> PermitDynamic<TArgument, TState, TTrigger>(
+            this StateConfiguration<TState, TTrigger> config,
+            ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<TArgument, DynamicState<TState>> targetStatePredicate,
+            Action<TArgument> onTriggerAction)
+        {
+            Contract.NotNull(onTriggerAction != null, nameof(onTriggerAction));
+
+            return config.PermitDynamic(trigger, targetStatePredicate,
+                (t, a) => onTriggerAction(a));
+        }
     }
 }

--- a/LiquidState/Synchronous/Core/ExecutionHelper.cs
+++ b/LiquidState/Synchronous/Core/ExecutionHelper.cs
@@ -134,7 +134,7 @@ namespace LiquidState.Synchronous.Core
             if (StateConfigurationHelper.CheckFlag(triggerRep.TransitionFlags,
                 TransitionFlag.DynamicState))
             {
-                var dynamicState = ((Func<DynamicState<TState>>) triggerRep.NextStateRepresentationWrapper)();
+                var dynamicState = ((Func<TArgument, DynamicState<TState>>) triggerRep.NextStateRepresentationWrapper)(argument);
                 if (!dynamicState.CanTransition) return;
 
                 var state = dynamicState.ResultingState;

--- a/LiquidState/Synchronous/Core/StateConfiguration.cs
+++ b/LiquidState/Synchronous/Core/StateConfiguration.cs
@@ -162,6 +162,14 @@ namespace LiquidState.Synchronous.Core
             Func<DynamicState<TState>> targetStatePredicate,
             Action<Transition<TState, TTrigger>, TArgument> onEntryAction)
         {
+            return Helper.PermitDynamic(this, trigger, a => targetStatePredicate(), onEntryAction);
+        }
+
+        public StateConfiguration<TState, TTrigger> PermitDynamic<TArgument>(
+            ParameterizedTrigger<TTrigger, TArgument> trigger,
+            Func<TArgument, DynamicState<TState>> targetStatePredicate,
+            Action<Transition<TState, TTrigger>, TArgument> onEntryAction)
+        {
             return Helper.PermitDynamic(this, trigger, targetStatePredicate, onEntryAction);
         }
 

--- a/LiquidState/Synchronous/Core/StateConfigurationMethodHelper.cs
+++ b/LiquidState/Synchronous/Core/StateConfigurationMethodHelper.cs
@@ -50,7 +50,7 @@ namespace LiquidState.Synchronous.Core
 
         internal static StateConfiguration<TState, TTrigger> PermitDynamic<TArgument, TState, TTrigger>(
             StateConfiguration<TState, TTrigger> config, ParameterizedTrigger<TTrigger, TArgument> trigger,
-            Func<DynamicState<TState>> targetStatePredicate,
+            Func<TArgument, DynamicState<TState>> targetStatePredicate,
             Action<Transition<TState, TTrigger>, TArgument> onTriggerAction)
         {
             return PermitDynamicCore(config, trigger.Trigger, targetStatePredicate, onTriggerAction);
@@ -95,7 +95,7 @@ namespace LiquidState.Synchronous.Core
 
         private static StateConfiguration<TState, TTrigger> PermitDynamicCore<TState, TTrigger>(
             StateConfiguration<TState, TTrigger> config, TTrigger trigger,
-            Func<DynamicState<TState>> targetStatePredicate, object onTriggerAction)
+            object targetStatePredicate, object onTriggerAction)
         {
             Contract.NotNull(trigger != null, nameof(trigger));
             Contract.NotNull(targetStatePredicate != null, nameof(targetStatePredicate));


### PR DESCRIPTION
For dynamic states, include the trigger parameter when calling the target state predicate. This allows state transitions to be based on the value of the parameter.

This should be a reasonable workaround to issue #26 