### PR TITLE
Include the trigger in the callback state.

### DIFF
--- a/LiquidState/Awaitable/Core/AwaitableExecutionHelper.cs
+++ b/LiquidState/Awaitable/Core/AwaitableExecutionHelper.cs
@@ -133,7 +133,7 @@ namespace LiquidState.Awaitable.Core
             }
 
 
-            var transition = new Transition<TState, TTrigger>(currentStateRepresentation.State, nextStateRep.State);
+            var transition = new Transition<TState, TTrigger>(currentStateRepresentation.State, nextStateRep.State, trigger);
 
             machine.RaiseTransitionStarted(nextStateRep.State);
 
@@ -244,7 +244,7 @@ namespace LiquidState.Awaitable.Core
             }
 
 
-            var transition = new Transition<TState, TTrigger>(currentStateRepresentation.State, nextStateRep.State);
+            var transition = new Transition<TState, TTrigger>(currentStateRepresentation.State, nextStateRep.State, trigger);
 
             machine.RaiseTransitionStarted(nextStateRep.State);
 

--- a/LiquidState/Synchronous/Core/ExecutionHelper.cs
+++ b/LiquidState/Synchronous/Core/ExecutionHelper.cs
@@ -86,7 +86,7 @@ namespace LiquidState.Synchronous.Core
             { nextStateRep = (StateRepresentation<TState, TTrigger>) triggerRep.NextStateRepresentationWrapper; }
 
 
-            var transition = new Transition<TState, TTrigger>(currentStateRepresentation.State, nextStateRep.State);
+            var transition = new Transition<TState, TTrigger>(currentStateRepresentation.State, nextStateRep.State, trigger);
 
             machine.RaiseTransitionStarted(nextStateRep.State);
 
@@ -151,7 +151,7 @@ namespace LiquidState.Synchronous.Core
             { nextStateRep = (StateRepresentation<TState, TTrigger>) triggerRep.NextStateRepresentationWrapper; }
 
 
-            var transition = new Transition<TState, TTrigger>(currentStateRepresentation.State, nextStateRep.State);
+            var transition = new Transition<TState, TTrigger>(currentStateRepresentation.State, nextStateRep.State, trigger);
 
             machine.RaiseTransitionStarted(nextStateRep.State);
 


### PR DESCRIPTION
The Transition class has a member for the trigger but it wasn't being set.  This PR includes the trigger in the Transition argument to the onTriggerAction delegate.
